### PR TITLE
Feature commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ The following MCP tools are available:
 - `get_selected_text()` — Get currently selected text
 - `get_all_classes()` — List all classes in the project
 - `get_class_source()` — Get full source of a given class
-- `get_method_by_name()` — Fetch a method’s source
+- `get_method_by_name()` — Fetch a method's source
 - `search_method_by_name()` — Search method across classes
+- `search_classes_by_keyword()` — Search for classes whose source code contains a specific keyword (supports pagination)
 - `get_methods_of_class()` — List methods in a class
 - `get_fields_of_class()` — List fields in a class
 - `get_smali_of_class()` — Fetch smali of class

--- a/src/main/java/com/zin/jadxaimcp/JadxAIMCP.java
+++ b/src/main/java/com/zin/jadxaimcp/JadxAIMCP.java
@@ -236,6 +236,7 @@ public class JadxAIMCP implements JadxPlugin {
             app.get("/selected-text", this::handleSelectedText);
             app.get("/method-by-name", this::handleMethodByName);
             app.get("/class-source", this::handleClassSource);
+            app.get("/search-classes-by-keyword", this::handleSearchClassesByKeyword);
             app.get("/search-method", this::handleSearchMethod);
             app.get("/methods-of-class", this::handleMethodsOfClass);
             app.get("/fields-of-class", this::handleFieldsOfClass);
@@ -940,6 +941,55 @@ public class JadxAIMCP implements JadxPlugin {
         } catch (Exception e) {
             logger.error("JADX AI MCP Error: " + e.getMessage(), e);
             ctx.status(500).json(Map.of("error", "Internal error during method search: " + e.getMessage()));
+        }
+    }
+
+    // method to handle /search-classes-by-keyword
+    private void handleSearchClassesByKeyword(Context ctx) {
+        String searchTerm = ctx.queryParam("search_term");
+
+        if (searchTerm == null || searchTerm.isEmpty()) {
+            logger.error("JADX AI MCP Error: Missing 'search_term' parameter.");
+            ctx.status(400).json(Map.of("error", "Missing 'search_term' parameter"));
+            return;
+        }
+
+        try {
+            JadxWrapper wrapper = mainWindow.getWrapper();
+            List<JavaClass> allClasses = wrapper.getIncludedClassesWithInners();
+            
+            String term = searchTerm.toLowerCase();
+
+            // Use parallel stream for faster processing of code search
+            List<JavaClass> matchingClasses = allClasses.parallelStream()
+                .filter(cls -> {
+                    try {
+                        // Check if class code contains the search term
+                        // This implicitly covers class name as well since class definition is part of the code
+                        String code = cls.getCode();
+                        return code != null && code.toLowerCase().contains(term);
+                    } catch (Exception e) {
+                        logger.warn("Failed to decompile class " + cls.getFullName() + " for search: " + e.getMessage());
+                        return false;
+                    }
+                })
+                .collect(Collectors.toList());
+
+            Map<String, Object> result = PaginationUtils.handlePagination(
+                    ctx,
+                    matchingClasses,
+                    "class-list",
+                    "classes",
+                    cls -> cls.getFullName());
+
+            ctx.json(result);
+
+        } catch (PaginationUtils.PaginationException e) {
+            logger.error("JADX AI MCP Pagination Error: " + e.getMessage());
+            ctx.status(400).json(Map.of("error", "Pagination error: " + e.getMessage()));
+        } catch (Exception e) {
+            logger.error("JADX AI MCP Error: " + e.getMessage(), e);
+            ctx.status(500).json(Map.of("error", "Internal error during search: " + e.getMessage()));
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Title
```
feat: Add search-classes-by-keyword endpoint with pagination support
```

## Description

### Summary

This PR adds a new MCP tool `search_classes_by_keyword()` that enables searching for classes whose source code contains a specific keyword, with pagination support for handling large result sets efficiently.

### Motivation

During Android APK reverse engineering and security analysis, analysts often need to quickly locate classes that contain specific keywords (e.g., "encrypt", "password", "API_KEY", etc.). The existing `get_all_classes()` tool only lists class names, and manually searching through decompiled code is time-consuming. This feature provides a powerful search capability that scans the actual source code of all classes.

### Changes Made

1. **New HTTP Endpoint**: Added `/search-classes-by-keyword` endpoint
   - Accepts `search_term` parameter (required)
   - Supports `offset` and `limit` parameters for pagination
   - Case-insensitive search across all class source code

2. **Implementation Details**:
   - Uses parallel streams for faster processing on large codebases
   - Searches through decompiled source code of all classes
   - Leverages existing `PaginationUtils` for consistent pagination behavior
   - Comprehensive error handling with proper logging

3. **Documentation Updates**:
   - Added tool description to README.md in the "Current MCP Tools" section

### Technical Implementation

- **File**: `src/main/java/com/zin/jadxaimcp/JadxAIMCP.java`
- **Method**: `handleSearchClassesByKeyword(Context ctx)`
- **Search Strategy**: 
  - Retrieves all classes using `wrapper.getIncludedClassesWithInners()`
  - Filters using parallel stream for performance
  - Checks if `cls.getCode()` contains the search term (case-insensitive)
  - Returns paginated results with class full names

### Example Usage

```bash
# Search for classes containing "encrypt"
GET /search-classes-by-keyword?search_term=encrypt&offset=0&limit=5

# Response format
{
    pagination: {
    total: 3446,
    offset: 0,
    limit: 5,
    count: 5,
    has_more: true,
    total_pages: 690,
    next_offset: 5,
    current_page: 1,
    page_size: 5
    },
    classes: [
        "android.support.v4.app.INotificationSideChannel",
        "android.support.v4.app.RemoteActionCompatParcelizer",
        "android.support.v4.graphics.drawable.IconCompatParcelizer",
        "android.support.v4.os.IResultReceiver",
        "android.support.v4.os.ResultReceiver"
],
    type: "class-list",
    requested_count: 5
}
```
### Testing

- [✅ ] mvn clean package and installed by jadx1.5.3
- [✅ ] test the endpoint **search-classes-by-keyword** ,it works correct as we expected

### Others
-[⚠️] Not implemented the mcp_server with python and I will implement it later
-[⚠️] pom.xml has not updated the plugin version